### PR TITLE
Polished data_fetcher.py (use encoding='utf-8')

### DIFF
--- a/flair/data_fetcher.py
+++ b/flair/data_fetcher.py
@@ -384,7 +384,7 @@ class NLPTaskDataFetcher:
         label_prefix = '__label__'
         sentences = []
 
-        with open(str(path_to_file)) as f:
+        with open(str(path_to_file), encoding='utf-8') as f:
             for line in f:
                 words = line.split()
 


### PR DESCRIPTION
According to https://github.com/zalandoresearch/flair/issues/67 , iamyihwa (https://github.com/iamyihwa), she fixed this inconvenience when using pip install flair (anaconda python3.6) on ubuntu. I followed her solution and my could not be read Japanese text input data issue was solved.

cr. iamyihwa